### PR TITLE
feat: server accepting POST request and parsing body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/package-lock.json
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "direct-back-end",
+  "version": "1.0.0",
+  "description": "backend for direct application",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ThomKaar/direct-back-end.git"
+  },
+  "author": "Thomkaar@gmail.com",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ThomKaar/direct-back-end/issues"
+  },
+  "homepage": "https://github.com/ThomKaar/direct-back-end#readme",
+  "dependencies": {
+    "body-parser": "^1.20.0",
+    "cors": "^2.8.5",
+    "express": "^4.18.1"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const cors = require('cors');
+const bodyParser = require('body-parser');
+const app = express();
+
+const port = 8080;
+
+const allowedDomains = ['http://localhost:3000'];
+// allow certain domains to make requests
+app.use(
+  cors({
+    origin: allowedDomains,
+    credentials: true
+  })
+);
+// handler js bodies
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+
+app.get('/', (req, res) => {
+  res.send('Hello World! This is the direct-back-end');
+})
+
+app.post('/cast', (req, res) => {
+  res.send('Success');
+});
+
+app.listen(port, () => {
+  console.log(`We are taking requests on port ${port}`);
+})


### PR DESCRIPTION
## Goals 
- setup server listening on port 8080
- accept requests from localhost:3000
- parse request json bodies
- handle POST requests to `/cast`, but don't do anything with it rn.